### PR TITLE
Fetch default branch name from repo instead of assuming "main"

### DIFF
--- a/lib/gitingest/generator.rb
+++ b/lib/gitingest/generator.rb
@@ -215,8 +215,6 @@ module Gitingest
 
     # Fetch repository contents and apply exclusion filters
     def fetch_repository_contents
-      options[:branch] = @client.repository(@options[:repository]).default_branch if options[:branch] == :default
-
       @logger.info "Fetching repository: #{@options[:repository]} (branch: #{@options[:branch]})"
       begin
         validate_repository_access
@@ -246,6 +244,8 @@ module Gitingest
       rescue Octokit::NotFound
         raise "Repository '#{@options[:repository]}' not found or is private. Check the repository name or provide a valid token."
       end
+
+      options[:branch] = @client.repository(@options[:repository]).default_branch if options[:branch] == :default
 
       begin
         @client.branch(@options[:repository], @options[:branch])

--- a/lib/gitingest/generator.rb
+++ b/lib/gitingest/generator.rb
@@ -187,7 +187,7 @@ module Gitingest
       raise ArgumentError, "Repository is required" unless @options[:repository]
 
       @options[:output_file] ||= "#{@options[:repository].split("/").last}_prompt.txt"
-      @options[:branch] ||= "main"
+      @options[:branch] ||= :default
       @options[:exclude] ||= []
       @options[:threads] ||= DEFAULT_THREAD_COUNT
       @options[:thread_timeout] ||= DEFAULT_THREAD_TIMEOUT
@@ -215,6 +215,8 @@ module Gitingest
 
     # Fetch repository contents and apply exclusion filters
     def fetch_repository_contents
+      options[:branch] = @client.repository(@options[:repository]).default_branch if options[:branch] == :default
+
       @logger.info "Fetching repository: #{@options[:repository]} (branch: #{@options[:branch]})"
       begin
         validate_repository_access


### PR DESCRIPTION
Calls `Octokit`'s `.default_branch` to dynamically get the default branch name instead of the hardcoded (usually correct) assumption of `main`.

Came across this because this repo uses `master` and I'd imagine I'm not the only one to run `gitingest -r davidesantangelo/gitingest` first thing and get a disheartening `Error: Branch 'main' not found in repository 'davidesantangelo/gitingest'` :)