### PR TITLE
Convert DEFAULT_EXCLUDES to ruby regexes

### DIFF
--- a/lib/gitingest/generator.rb
+++ b/lib/gitingest/generator.rb
@@ -28,7 +28,7 @@ module Gitingest
 
       # Dependency directories
       /node_modules\//, /vendor\//, /bower_components\//, /\.npm\//, /\.yarn\//, /\.pnpm-store\//,
-      /\.bundle\//, /vendor\/bundle/, /packages\//, /site-packages\//,
+      /\.bundle\//, /packages\//, /site-packages\//,
 
       # Virtual environments
       /venv\//, /\.venv\//, /env\//, /\.env/, /virtualenv\//,
@@ -42,8 +42,8 @@ module Gitingest
       /Gemfile\.lock/, /Cargo\.lock/, /bun\.lock/, /bun\.lockb/,
 
       # Build directories and artifacts
-      /build\//, /dist\//, /target\//, /out\//, /\.gradle\//, /\.settings\//,
-      /.*\.egg-info/, /.*\.egg/, /.*\.whl/, /.*\.so/, /bin\//, /obj\//, /pkg\//,
+      /build\//, /dist\//, /target\//, /out\//, /\.gradle\//,
+      /.*\.egg-info\//, /.*\.egg/, /.*\.whl/, /.*\.so/, /bin\//, /obj\//, /pkg\//,
 
       # Cache directories
       /\.cache\//, /\.sass-cache\//, /\.eslintcache\//, /\.pytest_cache\//,
@@ -59,8 +59,8 @@ module Gitingest
       # Language-specific files
       /.*\.min\.js$/, /.*\.min\.css$/, /.*\.map$/, /.*\.tfstate.*/,
       /.*\.gem$/, /.*\.ruby-version/, /.*\.ruby-gemset/, /.*\.rvmrc/,
-      /.*\.rs\.bk$/, /.*\.gradle/, /.*\.suo/, /.*\.user/, /.*\.userosscache/,
-      /.*\.sln\.docstates/, /gradle-app\.setting/,
+      /.*\.rs\.bk$/, /.*\.suo/, /.*\.user/, /.*\.userosscache/,
+      /.*\.sln\.docstates/, /gradle-app\.setting/, /gradlew*/,
       /.*\.pbxuser/, /.*\.mode1v3/, /.*\.mode2v3/, /.*\.perspectivev3/, /.*\.xcuserstate/,
       /\.swiftpm\//, /\.build\//
     ].freeze

--- a/lib/gitingest/generator.rb
+++ b/lib/gitingest/generator.rb
@@ -11,58 +11,58 @@ module Gitingest
     # Default exclusion patterns for common files and directories
     DEFAULT_EXCLUDES = [
       # Version control
-      '\.git/', '\.github/', '\.gitignore', '\.gitattributes', '\.gitmodules', '\.svn', '\.hg',
+      /\.git\//, /\.github\//, /\.gitignore/, /\.gitattributes/, /\.gitmodules/, /\.svn/, /\.hg/,
 
       # System files
-      '\.DS_Store', 'Thumbs\.db', 'desktop\.ini',
+      /\.DS_Store/, /Thumbs\.db/, /desktop\.ini/,
 
       # Log files
-      '.*\.log$', '.*\.bak$', '.*\.swp$', '.*\.tmp$', '.*\.temp$',
+      /.*\.log$/, /.*\.bak$/, /.*\.swp$/, /.*\.tmp$/, /.*\.temp$/,
 
       # Images and media
-      '.*\.png$', '.*\.jpg$', '.*\.jpeg$', '.*\.gif$', '.*\.svg$', '.*\.ico$',
-      '.*\.pdf$', '.*\.mov$', '.*\.mp4$', '.*\.mp3$', '.*\.wav$',
+      /.*\.png$/, /.*\.jpg$/, /.*\.jpeg$/, /.*\.gif$/, /.*\.svg$/, /.*\.ico$/,
+      /.*\.pdf$/, /.*\.mov$/, /.*\.mp4$/, /.*\.mp3$/, /.*\.wav$/,
 
       # Archives
-      '.*\.zip$', '.*\.tar\.gz$',
+      /.*\.zip$/, /.*\.tar\.gz$/,
 
       # Dependency directories
-      "node_modules/", "vendor/", "bower_components/", "\.npm/", "\.yarn/", "\.pnpm-store/",
-      "\.bundle/", "vendor/bundle", "packages/", "site-packages/",
+      /node_modules\//, /vendor\//, /bower_components\//, /\.npm\//, /\.yarn\//, /\.pnpm-store\//,
+      /\.bundle\//, /vendor\/bundle/, /packages\//, /site-packages\//,
 
       # Virtual environments
-      "venv/", "\.venv/", "env/", "\.env", "virtualenv/",
+      /venv\//, /\.venv\//, /env\//, /\.env/, /virtualenv\//,
 
       # IDE and editor files
-      "\.idea/", "\.vscode/", "\.vs/", "\.settings/", ".*\.sublime-.*",
-      "\.project", "\.classpath", "xcuserdata/", ".*\.xcodeproj/", ".*\.xcworkspace/",
+      /\.idea\//, /\.vscode\//, /\.vs\//, /\.settings\//, /.*\.sublime-.*/,
+      /\.project/, /\.classpath/, /xcuserdata\//, /.*\.xcodeproj\//, /.*\.xcworkspace\//,
 
       # Lock files
-      "package-lock\.json", "yarn\.lock", "poetry\.lock", "Pipfile\.lock",
-      "Gemfile\.lock", "Cargo\.lock", "bun\.lock", "bun\.lockb",
+      /package-lock\.json/, /yarn\.lock/, /poetry\.lock/, /Pipfile\.lock/,
+      /Gemfile\.lock/, /Cargo\.lock/, /bun\.lock/, /bun\.lockb/,
 
       # Build directories and artifacts
-      "build/", "dist/", "target/", "out/", "\.gradle/", "\.settings/",
-      ".*\.egg-info", ".*\.egg", ".*\.whl", ".*\.so", "bin/", "obj/", "pkg/",
+      /build\//, /dist\//, /target\//, /out\//, /\.gradle\//, /\.settings\//,
+      /.*\.egg-info/, /.*\.egg/, /.*\.whl/, /.*\.so/, /bin\//, /obj\//, /pkg\//,
 
       # Cache directories
-      "\.cache/", "\.sass-cache/", "\.eslintcache/", "\.pytest_cache/",
-      "\.coverage", "\.tox/", "\.nox/", "\.mypy_cache/", "\.ruff_cache/",
-      "\.hypothesis/", "\.terraform/", "\.docusaurus/", "\.next/", "\.nuxt/",
+      /\.cache\//, /\.sass-cache\//, /\.eslintcache\//, /\.pytest_cache\//,
+      /\.coverage/, /\.tox\//, /\.nox\//, /\.mypy_cache\//, /\.ruff_cache\//,
+      /\.hypothesis\//, /\.terraform\//, /\.docusaurus\//, /\.next\//, /\.nuxt\//,
 
       # Compiled code
-      ".*\.pyc$", ".*\.pyo$", ".*\.pyd$", "__pycache__/", ".*\.class$",
-      ".*\.jar$", ".*\.war$", ".*\.ear$", ".*\.nar$",
-      ".*\.o$", ".*\.obj$", ".*\.dll$", ".*\.dylib$", ".*\.exe$",
-      ".*\.lib$", ".*\.out$", ".*\.a$", ".*\.pdb$", ".*\.nupkg$",
+      /.*\.pyc$/, /.*\.pyo$/, /.*\.pyd$/, /__pycache__\//, /.*\.class$/,
+      /.*\.jar$/, /.*\.war$/, /.*\.ear$/, /.*\.nar$/,
+      /.*\.o$/, /.*\.obj$/, /.*\.dll$/, /.*\.dylib$/, /.*\.exe$/,
+      /.*\.lib$/, /.*\.out$/, /.*\.a$/, /.*\.pdb$/, /.*\.nupkg$/,
 
       # Language-specific files
-      ".*\.min\.js$", ".*\.min\.css$", ".*\.map$", ".*\.tfstate.*",
-      ".*\.gem$", ".*\.ruby-version", ".*\.ruby-gemset", ".*\.rvmrc",
-      ".*\.rs\.bk$", ".*\.gradle", ".*\.suo", ".*\.user", ".*\.userosscache",
-      ".*\.sln\.docstates", "gradle-app\.setting",
-      ".*\.pbxuser", ".*\.mode1v3", ".*\.mode2v3", ".*\.perspectivev3", ".*\.xcuserstate",
-      "\.swiftpm/", "\.build/"
+      /.*\.min\.js$/, /.*\.min\.css$/, /.*\.map$/, /.*\.tfstate.*/,
+      /.*\.gem$/, /.*\.ruby-version/, /.*\.ruby-gemset/, /.*\.rvmrc/,
+      /.*\.rs\.bk$/, /.*\.gradle/, /.*\.suo/, /.*\.user/, /.*\.userosscache/,
+      /.*\.sln\.docstates/, /gradle-app\.setting/,
+      /.*\.pbxuser/, /.*\.mode1v3/, /.*\.mode2v3/, /.*\.perspectivev3/, /.*\.xcuserstate/,
+      /\.swiftpm\//, /\.build\//
     ].freeze
 
     # Pattern for dot files/directories
@@ -170,7 +170,7 @@ module Gitingest
     end
 
     def compile_excluded_patterns
-      @default_patterns = DEFAULT_EXCLUDES.map { |pattern| Regexp.new(pattern) }
+      @default_patterns = DEFAULT_EXCLUDES
       @custom_glob_patterns = [] # For File.fnmatch
       @directory_patterns = []
 

--- a/spec/gitingest_spec.rb
+++ b/spec/gitingest_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe Gitingest do
 
       it "doesn't exclude regular code files" do
         expect(generator.send(:excluded_file?, "lib/gitingest.rb")).to be false
+        expect(generator.send(:excluded_file?, "src/App.java")).to be false
         expect(generator.send(:excluded_file?, "README.md")).to be false
       end
 


### PR DESCRIPTION
They are currently strings and subtle bugs around escape(\) that are broken when strings are compiled into regexes.

For example: the file "src/App.java" is excluded because it ends with an "a". This happens because the string ".*\.a$" interprets the (\) as an escape for the (.).

Converting the strings to the ruby regex format makes it easier not to make such errors.
Fixes #8 